### PR TITLE
adding scraping script for us news state equality ranking

### DIFF
--- a/scripts/gather/scrape_usnews.py
+++ b/scripts/gather/scrape_usnews.py
@@ -1,31 +1,87 @@
+"""
+This script scrapes the US News Best States website for the equality rank of all 50 US states and writes the results to a CSV file.
 
-import requests
-from bs4 import BeautifulSoup
+When this code breaks, we probably need to change the "soup.find('span', {'data-test-id': 'equality-rank'})" line to match the new HTML structure.
 
-#! This isn't working. All my requests to usnews.com are timing out. It works for other sites though...
+"""
 
-def main():
-    """
-    """
+from utils import get_soup, write_array_to_csv
 
-    # Make a request to the website
-    url = 'https://www.usnews.com/news/best-states/articles/maryland-is-the-best-state-for-gender-equality'
 
-    headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'}
-    
-    response = requests.get(url, headers=headers)
+list_of_states = [
+    'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado',
+    'Connecticut', 'Delaware', 'Florida', 'Georgia', 'Hawaii', 'Idaho',
+    'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana',
+    'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota',
+    'Mississippi', 'Missouri', 'Montana', 'Nebraska', 'Nevada',
+    'New Hampshire', 'New Jersey', 'New Mexico', 'New York',
+    'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon',
+    'Pennsylvania', 'Rhode Island', 'South Carolina', 'South Dakota',
+    'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virginia', 'Washington',
+    'West Virginia', 'Wisconsin', 'Wyoming'
+]
 
-    # Parse the HTML content using BeautifulSoup
-    soup = BeautifulSoup(response.content, 'html.parser')
 
-    # save soup to txt file
-    with open('soup.txt', 'w') as f:
-        f.write(str(soup))
+def get_state_data(state):
+    '''
+    Returns the equality rank of a state, given the state name as a string.
 
+    Parameters:
+    state (str): The name of the state to look up.
+
+    Returns:
+    int: The equality rank of the state, as an integer, -1 if the equality rank is not found.
+    '''
+
+    # if there is a space in the state name, replace it with a dash
+    if ' ' in state:
+        state = state.replace(' ', '-')
+
+    # Base URL for the US News Best States website
+    base_url = 'https://www.usnews.com/news/best-states/'
+
+    # Get the parsed HTML content of the webpage
+    soup = get_soup(base_url + state.lower())
+
+    # Extract the equality rank from the webpage
+    equality_rank_span = soup.find('span', {'data-test-id': 'equality-rank'})
+
+    # Raise an AttributeError if the equality rank element is not found
+    if equality_rank_span is None:
+        return -1
+
+    # Extract the integer value from the equality rank element and return it
+    equality_rank = int(equality_rank_span.text.strip('#'))
+    return equality_rank
+
+
+def get_all_state_data():
+    '''
+    Retrieves the equality rank of all 50 US states and returns the results as a NumPy array.
+
+    Returns:
+    numpy.ndarray: A NumPy array containing the state name and its equality rank for all 50 US states.
+    '''
+
+    results = []
+
+    results.append(['State', 'Equality Rank'])
+
+    # Loop through all 50 states and get their equality rank
+    for i, state in enumerate(list_of_states):
+        equality_rank = get_state_data(state)
+        results.append([state, equality_rank])
+
+        # Print the progress counter
+        print(f'\rReading states: {i+1}/{len(list_of_states)}', end='')
+
+    print()
+
+    write_array_to_csv(results, 'usnews_state_equality_rankings.csv')
+
+    return results
 
 
 if __name__ == '__main__':
-    main()
 
-
+    get_all_state_data()

--- a/scripts/gather/utils.py
+++ b/scripts/gather/utils.py
@@ -1,0 +1,72 @@
+"""
+
+Useful functions for the gathering scripts
+
+"""
+
+import requests
+from bs4 import BeautifulSoup
+import time
+import csv
+import os
+
+
+def get_soup(url):
+    '''
+    Retrieves and parses the HTML content of a webpage using Beautiful Soup.
+
+    Parameters:
+    url (str): The URL of the webpage to retrieve and parse.
+
+    Returns:
+    BeautifulSoup object: The parsed HTML content of the webpage.
+    '''
+
+    # Set the headers to simulate a browser request
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'
+    }
+
+    # Sleep for half a second to avoid overloading the website
+    time.sleep(.5) 
+
+    # Make a GET request to the website for the specified state
+    response = requests.get(url, headers=headers)
+
+    # Parse the HTML content using BeautifulSoup
+    return BeautifulSoup(response.content, 'html.parser')
+
+
+def write_array_to_csv(results, csv_file_name):
+    '''
+    Writes the results of a state equality ranking to a CSV file.
+
+    Parameters:
+    results (numpy.ndarray): A NumPy array containing the state name and its equality rank.
+    csv_file (str): The name of the CSV file to write the results to.
+    '''
+
+    processed_data_directory = get_processed_data_directory()
+    save_path = os.path.join(processed_data_directory, csv_file_name)
+
+    # Open the CSV file for writing
+    with open(save_path, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+
+        # Write each result row
+        for row in results:
+            writer.writerow(row)
+
+
+def get_processed_data_directory():
+    '''
+    Returns the path to the processed data directory.
+    '''
+
+    return os.path.abspath(f"{__file__}/../../../data/processed_data")
+
+
+
+if __name__ == '__main__':
+
+    pass


### PR DESCRIPTION
Running `scrape_usnews.py` pulls all the state equality ranking data from the us news site and save it in a csv file named 'usnews_state_equality_ranking.csv'.

Is this close to what you were thinking? Let me know what I can change to make it more helpful!